### PR TITLE
deduplication

### DIFF
--- a/ardent/distribution.yaml
+++ b/ardent/distribution.yaml
@@ -6,335 +6,29 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
-  actionlib_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/common_interfaces.git
-      version: master
-    status: maintained
-  amcl:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/navigation-release.git
-      version: 1.14.0-4
-    source:
-      type: git
-      url: https://github.com/ros2/navigation.git
-      version: ros2
-    status: maintained
-  ament_clang_format:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
   ament_cmake:
     release:
+      packages:
+      - ament_cmake
+      - ament_cmake_auto
+      - ament_cmake_core
+      - ament_cmake_export_definitions
+      - ament_cmake_export_dependencies
+      - ament_cmake_export_include_directories
+      - ament_cmake_export_interfaces
+      - ament_cmake_export_libraries
+      - ament_cmake_export_link_flags
+      - ament_cmake_gmock
+      - ament_cmake_gtest
+      - ament_cmake_include_directories
+      - ament_cmake_libraries
+      - ament_cmake_nose
+      - ament_cmake_pytest
+      - ament_cmake_python
+      - ament_cmake_target_dependencies
+      - ament_cmake_test
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_auto:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_clang_format:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_cmake_copyright:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_cmake_core:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_cppcheck:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_cmake_cpplint:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_cmake_export_definitions:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_export_dependencies:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_export_include_directories:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_export_interfaces:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_export_libraries:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_export_link_flags:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_flake8:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_cmake_gmock:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_gtest:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_include_directories:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_libraries:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_lint_cmake:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_cmake_nose:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_pep257:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_cmake_pep8:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_cmake_pyflakes:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_cmake_pytest:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_python:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/ament_cmake-release.git
       version: 0.0.3-5
     source:
@@ -346,7 +40,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
       version: 0.0.3-1
     source:
@@ -354,95 +47,13 @@ repositories:
       url: https://github.com/ros2/ament_cmake_ros.git
       version: master
     status: maintained
-  ament_cmake_target_dependencies:
+  ament_index:
     release:
+      packages:
+      - ament_index_cpp
+      - ament_index_python
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_test:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.0.3-5
-    source:
-      type: git
-      url: https://github.com/ament/ament_cmake.git
-      version: master
-    status: maintained
-  ament_cmake_uncrustify:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_copyright:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_cppcheck:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_cpplint:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_flake8:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_index_cpp:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/ament_index-release.git
       version: 0.0.3-2
     source:
@@ -450,47 +61,33 @@ repositories:
       url: https://github.com/ament/ament_index.git
       version: master
     status: maintained
-  ament_index_python:
+  ament_lint:
     release:
+      packages:
+      - ament_clang_format
+      - ament_cmake_clang_format
+      - ament_cmake_copyright
+      - ament_cmake_cppcheck
+      - ament_cmake_cpplint
+      - ament_cmake_flake8
+      - ament_cmake_lint_cmake
+      - ament_cmake_pep257
+      - ament_cmake_pep8
+      - ament_cmake_pyflakes
+      - ament_cmake_uncrustify
+      - ament_copyright
+      - ament_cppcheck
+      - ament_cpplint
+      - ament_flake8
+      - ament_lint_auto
+      - ament_lint_cmake
+      - ament_lint_common
+      - ament_pep257
+      - ament_pep8
+      - ament_pyflakes
+      - ament_uncrustify
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_index.git
-      version: master
-    status: maintained
-  ament_lint_auto:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_lint_cmake:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_lint_common:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/ament_lint-release.git
       version: 0.0.3-2
     source:
@@ -502,7 +99,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/ament_package-release.git
       version: 0.0.3-2
     source:
@@ -510,47 +106,10 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: maintained
-  ament_pep257:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_pep8:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
-  ament_pyflakes:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
   ament_tools:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/ament_tools-release.git
       version: 0.0.3-1
     source:
@@ -558,23 +117,10 @@ repositories:
       url: https://github.com/ament/ament_tools.git
       version: master
     status: maintained
-  ament_uncrustify:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ament/ament_lint.git
-      version: master
-    status: maintained
   astra_camera:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/ros_astra_camera-release.git
       version: 0.2.0-9
     source:
@@ -582,23 +128,10 @@ repositories:
       url: https://github.com/ros2/ros_astra_camera.git
       version: master
     status: maintained
-  builtin_interfaces:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/rcl_interfaces.git
-      version: master
-    status: maintained
   cartographer:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/cartographer-release.git
       version: 0.1.0-11
     source:
@@ -608,21 +141,11 @@ repositories:
     status: maintained
   cartographer_ros:
     release:
+      packages:
+      - cartographer_ros
+      - cartographer_ros_msgs
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/cartographer_ros-release.git
-      version: 0.1.0-9
-    source:
-      type: git
-      url: https://github.com/ros2/cartographer_ros.git
-      version: ros2
-    status: maintained
-  cartographer_ros_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
       version: 0.1.0-9
     source:
@@ -634,7 +157,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/class_loader-release.git
       version: 1.0.0-12
     source:
@@ -644,9 +166,21 @@ repositories:
     status: maintained
   common_interfaces:
     release:
+      packages:
+      - actionlib_msgs
+      - common_interfaces
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - shape_msgs
+      - std_msgs
+      - std_srvs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/common_interfaces-release.git
       version: 0.0.3-2
     source:
@@ -654,23 +188,10 @@ repositories:
       url: https://github.com/ros2/common_interfaces.git
       version: master
     status: maintained
-  composition:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
   console_bridge:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/console_bridge-release.git
       version: 0.3.2-9
     source:
@@ -678,35 +199,25 @@ repositories:
       url: https://github.com/ros/console_bridge.git
       version: master
     status: maintained
-  demo_nodes_cpp:
+  demos:
     release:
+      packages:
+      - composition
+      - demo_nodes_cpp
+      - demo_nodes_cpp_native
+      - demo_nodes_py
+      - dummy_map_server
+      - dummy_robot_bringup
+      - dummy_sensors
+      - image_tools
+      - intra_process_demo
+      - lifecycle
+      - logging_demo
+      - pendulum_control
+      - pendulum_msgs
+      - topic_monitor
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
-  demo_nodes_cpp_native:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
-  demo_nodes_py:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/demos-release.git
       version: 0.0.3-2
     source:
@@ -718,7 +229,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
       version: 1.0.7-5
     source:
@@ -726,71 +236,10 @@ repositories:
       url: https://github.com/ros2/depthimage_to_laserscan.git
       version: master
     status: maintained
-  depthimage_to_pointcloud2:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/turtlebot2_demo-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/turtlebot2_demo.git
-      version: master
-    status: maintained
-  diagnostic_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/common_interfaces.git
-      version: master
-    status: maintained
-  dummy_map_server:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
-  dummy_robot_bringup:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
-  dummy_sensors:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
   example_interfaces:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/example_interfaces-release.git
       version: 0.0.3-1
     source:
@@ -798,131 +247,22 @@ repositories:
       url: https://github.com/ros2/example_interfaces.git
       version: master
     status: maintained
-  examples_rclcpp_minimal_client:
+  examples:
     release:
+      packages:
+      - examples_rclcpp_minimal_client
+      - examples_rclcpp_minimal_composition
+      - examples_rclcpp_minimal_publisher
+      - examples_rclcpp_minimal_service
+      - examples_rclcpp_minimal_subscriber
+      - examples_rclcpp_minimal_timer
+      - examples_rclpy_executors
+      - examples_rclpy_minimal_client
+      - examples_rclpy_minimal_publisher
+      - examples_rclpy_minimal_service
+      - examples_rclpy_minimal_subscriber
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/examples.git
-      version: master
-    status: maintained
-  examples_rclcpp_minimal_composition:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/examples.git
-      version: master
-    status: maintained
-  examples_rclcpp_minimal_publisher:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/examples.git
-      version: master
-    status: maintained
-  examples_rclcpp_minimal_service:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/examples.git
-      version: master
-    status: maintained
-  examples_rclcpp_minimal_subscriber:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/examples.git
-      version: master
-    status: maintained
-  examples_rclcpp_minimal_timer:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/examples.git
-      version: master
-    status: maintained
-  examples_rclpy_executors:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/examples.git
-      version: master
-    status: maintained
-  examples_rclpy_minimal_client:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/examples.git
-      version: master
-    status: maintained
-  examples_rclpy_minimal_publisher:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/examples.git
-      version: master
-    status: maintained
-  examples_rclpy_minimal_service:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/examples.git
-      version: master
-    status: maintained
-  examples_rclpy_minimal_subscriber:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/examples-release.git
       version: 0.0.3-2
     source:
@@ -934,7 +274,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/fastcdr-release.git
       version: 1.0.7-3
     source:
@@ -946,7 +285,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/fastrtps-release.git
       version: 1.5.0-9
     source:
@@ -954,35 +292,30 @@ repositories:
       url: https://github.com/eProsima/Fast-RTPS.git
       version: master
     status: maintained
-  fastrtps_cmake_module:
+  geometry2:
     release:
+      packages:
+      - tf2
+      - tf2_eigen
+      - tf2_geometry_msgs
+      - tf2_msgs
+      - tf2_ros
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 0.0.3-2
+      url: https://github.com/ros2-gbp/geometry2-release.git
+      version: 0.5.15-10
     source:
       type: git
-      url: https://github.com/ros2/rmw_fastrtps.git
-      version: master
+      url: https://github.com/ros2/geometry2.git
+      version: ros2
     status: maintained
-  geometry_msgs:
+  googletest:
     release:
+      packages:
+      - gmock_vendor
+      - gtest_vendor
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/common_interfaces.git
-      version: master
-    status: maintained
-  gmock_vendor:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/googletest-release.git
       version: 1.8.0-3
     source:
@@ -990,59 +323,12 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
-  gtest_vendor:
+  joystick_drivers:
     release:
+      packages:
+      - joy
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/googletest-release.git
-      version: 1.8.0-3
-    source:
-      type: git
-      url: https://github.com/ament/googletest.git
-      version: ros2
-    status: maintained
-  image_geometry:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 1.12.4-4
-    source:
-      type: git
-      url: https://github.com/ros2/vision_opencv.git
-      version: master
-    status: maintained
-  image_tools:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
-  intra_process_demo:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
-  joy:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/joy-release.git
       version: 1.11.0-4
     source:
@@ -1054,7 +340,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/kdl_parser-release.git
       version: 1.12.10-1
     source:
@@ -1064,9 +349,11 @@ repositories:
     status: maintained
   launch:
     release:
+      packages:
+      - launch
+      - launch_testing
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/launch-release.git
       version: 0.0.3-2
     source:
@@ -1074,71 +361,13 @@ repositories:
       url: https://github.com/ros2/launch.git
       version: master
     status: maintained
-  launch_testing:
+  navigation:
     release:
+      packages:
+      - amcl
+      - map_server
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/launch.git
-      version: master
-    status: maintained
-  libcurl_vendor:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 1.12.3-0
-    source:
-      type: git
-      url: https://github.com/ros/resource_retriever.git
-      version: ros2
-    status: maintained
-  lifecycle:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
-  lifecycle_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/rcl_interfaces.git
-      version: master
-    status: maintained
-  logging_demo:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
-  map_server:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/navigation-release.git
       version: 1.14.0-4
     source:
@@ -1146,35 +375,12 @@ repositories:
       url: https://github.com/ros2/navigation.git
       version: ros2
     status: maintained
-  nav_msgs:
+  orocos_kinematics_dynamics:
     release:
+      packages:
+      - orocos_kdl
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/common_interfaces.git
-      version: master
-    status: maintained
-  opensplice_cmake_module:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rmw_opensplice-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/rmw_opensplice.git
-      version: master
-    status: maintained
-  orocos_kdl:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
       version: 1.4.0-6
     source:
@@ -1186,7 +392,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
       version: 0.1.3-7
     source:
@@ -1198,7 +403,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/pcl_conversions-release.git
       version: 0.2.1-4
     source:
@@ -1206,35 +410,10 @@ repositories:
       url: https://github.com/ros2/pcl_conversions.git
       version: master
     status: maintained
-  pendulum_control:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
-  pendulum_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
   pluginlib:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/pluginlib-release.git
       version: 1.11.0-0
     source:
@@ -1246,7 +425,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/poco_vendor-release.git
       version: 0.0.3-4
     source:
@@ -1254,23 +432,13 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: maintained
-  python_cmake_module:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rosidl.git
-      version: master
-    status: maintained
   rcl:
     release:
+      packages:
+      - rcl
+      - rcl_lifecycle
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rcl-release.git
       version: 0.0.3-2
     source:
@@ -1280,9 +448,13 @@ repositories:
     status: maintained
   rcl_interfaces:
     release:
+      packages:
+      - builtin_interfaces
+      - lifecycle_msgs
+      - rcl_interfaces
+      - test_msgs
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
       version: 0.0.3-2
     source:
@@ -1290,35 +462,13 @@ repositories:
       url: https://github.com/ros2/rcl_interfaces.git
       version: master
     status: maintained
-  rcl_lifecycle:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rcl.git
-      version: master
-    status: maintained
   rclcpp:
     release:
+      packages:
+      - rclcpp
+      - rclcpp_lifecycle
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rclcpp.git
-      version: master
-    status: maintained
-  rclcpp_lifecycle:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rclcpp-release.git
       version: 0.0.3-1
     source:
@@ -1330,7 +480,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rclpy-release.git
       version: 0.0.3-1
     source:
@@ -1342,7 +491,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rcutils-release.git
       version: 0.0.3-1
     source:
@@ -1350,11 +498,27 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: master
     status: maintained
-  resource_retriever:
+  realtime_support:
     release:
+      packages:
+      - rttest
+      - tlsf_cpp
       tags:
         release: release/ardent/{package}/{version}
+      url: https://github.com/ros2-gbp/realtime_support-release.git
+      version: 0.0.3-1
+    source:
       type: git
+      url: https://github.com/ros2/realtime_support.git
+      version: master
+    status: maintained
+  resource_retriever:
+    release:
+      packages:
+      - libcurl_vendor
+      - resource_retriever
+      tags:
+        release: release/ardent/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
       version: 1.12.3-0
     source:
@@ -1364,9 +528,11 @@ repositories:
     status: maintained
   rmw:
     release:
+      packages:
+      - rmw
+      - rmw_implementation_cmake
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rmw-release.git
       version: 0.0.3-2
     source:
@@ -1374,11 +540,13 @@ repositories:
       url: https://github.com/ros2/rmw.git
       version: master
     status: maintained
-  rmw_fastrtps_cpp:
+  rmw_fastrtps:
     release:
+      packages:
+      - fastrtps_cmake_module
+      - rmw_fastrtps_cpp
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
       version: 0.0.3-2
     source:
@@ -1390,7 +558,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
       version: 0.0.3-4
     source:
@@ -1398,23 +565,15 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: master
     status: maintained
-  rmw_implementation_cmake:
+  rmw_opensplice:
     release:
+      packages:
+      - opensplice_cmake_module
+      - rmw_opensplice_cpp
+      - rosidl_typesupport_opensplice_c
+      - rosidl_typesupport_opensplice_cpp
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rmw-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/rmw.git
-      version: master
-    status: maintained
-  rmw_opensplice_cpp:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rmw_opensplice-release.git
       version: 0.0.3-2
     source:
@@ -1426,7 +585,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
       version: 1.13.4-5
     source:
@@ -1438,7 +596,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
       version: 0.0.3-2
     source:
@@ -1448,93 +605,16 @@ repositories:
     status: maintained
   ros2cli:
     release:
+      packages:
+      - ros2msg
+      - ros2node
+      - ros2pkg
+      - ros2run
+      - ros2service
+      - ros2srv
+      - ros2topic
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/ros2cli.git
-      version: master
-    status: maintained
-  ros2msg:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/ros2cli.git
-      version: master
-    status: maintained
-  ros2node:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/ros2cli.git
-      version: master
-    status: maintained
-  ros2pkg:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/ros2cli.git
-      version: master
-    status: maintained
-  ros2run:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/ros2cli.git
-      version: master
-    status: maintained
-  ros2service:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/ros2cli.git
-      version: master
-    status: maintained
-  ros2srv:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/ros2cli.git
-      version: master
-    status: maintained
-  ros2topic:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/ros2cli-release.git
       version: 0.0.3-1
     source:
@@ -1546,7 +626,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/ros_workspace-release.git
       version: 0.0.3-3
     source:
@@ -1554,11 +633,20 @@ repositories:
       url: https://github.com/nuclearsandwich/ros_workspace.git
       version: master
     status: maintained
-  rosidl_cmake:
+  rosidl:
     release:
+      packages:
+      - python_cmake_module
+      - rosidl_cmake
+      - rosidl_generator_c
+      - rosidl_generator_cpp
+      - rosidl_generator_py
+      - rosidl_parser
+      - rosidl_typesupport_interface
+      - rosidl_typesupport_introspection_c
+      - rosidl_typesupport_introspection_cpp
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rosidl-release.git
       version: 0.0.3-1
     source:
@@ -1566,59 +654,12 @@ repositories:
       url: https://github.com/ros2/rosidl.git
       version: master
     status: maintained
-  rosidl_default_generators:
+  rosidl_dds:
     release:
+      packages:
+      - rosidl_generator_dds_idl
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rosidl_typesupport.git
-      version: master
-    status: maintained
-  rosidl_default_runtime:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rosidl_typesupport.git
-      version: master
-    status: maintained
-  rosidl_generator_c:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rosidl.git
-      version: master
-    status: maintained
-  rosidl_generator_cpp:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rosidl.git
-      version: master
-    status: maintained
-  rosidl_generator_dds_idl:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rosidl_dds-release.git
       version: 0.0.3-1
     source:
@@ -1626,35 +667,15 @@ repositories:
       url: https://github.com/ros2/rosidl_dds.git
       version: master
     status: maintained
-  rosidl_generator_py:
+  rosidl_typesupport:
     release:
+      packages:
+      - rosidl_default_generators
+      - rosidl_default_runtime
+      - rosidl_typesupport_c
+      - rosidl_typesupport_cpp
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rosidl.git
-      version: master
-    status: maintained
-  rosidl_parser:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rosidl.git
-      version: master
-    status: maintained
-  rosidl_typesupport_c:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
       version: 0.0.3-1
     source:
@@ -1662,215 +683,30 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport.git
       version: master
     status: maintained
-  rosidl_typesupport_cpp:
+  rviz:
     release:
+      packages:
+      - rviz2
+      - rviz_assimp_vendor
+      - rviz_common
+      - rviz_default_plugins
+      - rviz_ogre_vendor
+      - rviz_rendering
+      - rviz_rendering_tests
+      - rviz_yaml_cpp_vendor
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rosidl_typesupport.git
-      version: master
-    status: maintained
-  rosidl_typesupport_interface:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rosidl.git
-      version: master
-    status: maintained
-  rosidl_typesupport_introspection_c:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rosidl.git
-      version: master
-    status: maintained
-  rosidl_typesupport_introspection_cpp:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/rosidl.git
-      version: master
-    status: maintained
-  rosidl_typesupport_opensplice_c:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rmw_opensplice-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/rmw_opensplice.git
-      version: master
-    status: maintained
-  rosidl_typesupport_opensplice_cpp:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rmw_opensplice-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/rmw_opensplice.git
-      version: master
-    status: maintained
-  rttest:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/realtime_support-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/realtime_support.git
-      version: master
-    status: maintained
-  rviz2:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 2.0.0-3
+      version: 2.0.0-4
     source:
       type: git
       url: https://github.com/ros2/rviz.git
       version: ros2
-    status: maintained
-  rviz_assimp_vendor:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rviz-release.git
-      version: 2.0.0-3
-    source:
-      type: git
-      url: https://github.com/ros2/rviz.git
-      version: ros2
-    status: maintained
-  rviz_common:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rviz-release.git
-      version: 2.0.0-3
-    source:
-      type: git
-      url: https://github.com/ros2/rviz.git
-      version: ros2
-    status: maintained
-  rviz_default_plugins:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rviz-release.git
-      version: 2.0.0-3
-    source:
-      type: git
-      url: https://github.com/ros2/rviz.git
-      version: ros2
-    status: maintained
-  rviz_ogre_vendor:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rviz-release.git
-      version: 2.0.0-3
-    source:
-      type: git
-      url: https://github.com/ros2/rviz.git
-      version: ros2
-    status: maintained
-  rviz_rendering:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rviz-release.git
-      version: 2.0.0-3
-    source:
-      type: git
-      url: https://github.com/ros2/rviz.git
-      version: ros2
-    status: maintained
-  rviz_rendering_tests:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rviz-release.git
-      version: 2.0.0-3
-    source:
-      type: git
-      url: https://github.com/ros2/rviz.git
-      version: ros2
-    status: maintained
-  rviz_yaml_cpp_vendor:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rviz-release.git
-      version: 2.0.0-3
-    source:
-      type: git
-      url: https://github.com/ros2/rviz.git
-      version: ros2
-    status: maintained
-  sensor_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/common_interfaces.git
-      version: master
-    status: maintained
-  shape_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/common_interfaces.git
-      version: master
     status: maintained
   sros2:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/sros2-release.git
       version: 0.0.3-1
     source:
@@ -1878,47 +714,10 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: master
     status: maintained
-  std_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/common_interfaces.git
-      version: master
-    status: maintained
-  std_srvs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/common_interfaces.git
-      version: master
-    status: maintained
-  stereo_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/common_interfaces.git
-      version: master
-    status: maintained
   teleop_twist_joy:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
       version: 0.1.2-5
     source:
@@ -1930,7 +729,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
       version: 0.6.0-5
     source:
@@ -1938,83 +736,10 @@ repositories:
       url: https://github.com/ros2/teleop_twist_keyboard.git
       version: master
     status: maintained
-  test_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/rcl_interfaces.git
-      version: master
-    status: maintained
-  tf2:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.5.15-10
-    source:
-      type: git
-      url: https://github.com/ros2/geometry2.git
-      version: ros2
-    status: maintained
-  tf2_eigen:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.5.15-10
-    source:
-      type: git
-      url: https://github.com/ros2/geometry2.git
-      version: ros2
-    status: maintained
-  tf2_geometry_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.5.15-10
-    source:
-      type: git
-      url: https://github.com/ros2/geometry2.git
-      version: ros2
-    status: maintained
-  tf2_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.5.15-10
-    source:
-      type: git
-      url: https://github.com/ros2/geometry2.git
-      version: ros2
-    status: maintained
-  tf2_ros:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.5.15-10
-    source:
-      type: git
-      url: https://github.com/ros2/geometry2.git
-      version: ros2
-    status: maintained
   tinyxml2_vendor:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
       version: 0.0.1-0
     source:
@@ -2026,7 +751,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
       version: 0.0.3-1
     source:
@@ -2038,7 +762,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/tlsf-release.git
       version: 0.0.3-1
     source:
@@ -2046,95 +769,17 @@ repositories:
       url: https://github.com/ros2/tlsf.git
       version: master
     status: maintained
-  tlsf_cpp:
+  turtlebot2_demo:
     release:
+      packages:
+      - depthimage_to_pointcloud2
+      - turtlebot2_amcl
+      - turtlebot2_cartographer
+      - turtlebot2_drivers
+      - turtlebot2_follower
+      - turtlebot2_teleop
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/realtime_support-release.git
-      version: 0.0.3-1
-    source:
-      type: git
-      url: https://github.com/ros2/realtime_support.git
-      version: master
-    status: maintained
-  topic_monitor:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/demos.git
-      version: master
-    status: maintained
-  trajectory_msgs:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/common_interfaces.git
-      version: master
-    status: maintained
-  turtlebot2_amcl:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/turtlebot2_demo-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/turtlebot2_demo.git
-      version: master
-    status: maintained
-  turtlebot2_cartographer:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/turtlebot2_demo-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/turtlebot2_demo.git
-      version: master
-    status: maintained
-  turtlebot2_drivers:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/turtlebot2_demo-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/turtlebot2_demo.git
-      version: master
-    status: maintained
-  turtlebot2_follower:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/turtlebot2_demo-release.git
-      version: 0.0.3-2
-    source:
-      type: git
-      url: https://github.com/ros2/turtlebot2_demo.git
-      version: master
-    status: maintained
-  turtlebot2_teleop:
-    release:
-      tags:
-        release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/turtlebot2_demo-release.git
       version: 0.0.3-2
     source:
@@ -2146,7 +791,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/uncrustify-release.git
       version: 0.61.20150413-7
     source:
@@ -2158,19 +802,17 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/urdf-release.git
       version: 1.12.12-1
     source:
       type: git
       url: https://github.com/ros2/urdf.git
-      version: urdf
+      version: ros2
     status: maintained
   urdfdom:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/urdfdom-release.git
       version: 0.3.0-9
     source:
@@ -2182,7 +824,6 @@ repositories:
     release:
       tags:
         release: release/ardent/{package}/{version}
-      type: git
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
       version: 1.0.0-3
     source:
@@ -2190,16 +831,17 @@ repositories:
       url: https://github.com/ros2/urdfdom_headers.git
       version: master
     status: maintained
-  visualization_msgs:
+  vision_opencv:
     release:
+      packages:
+      - image_geometry
       tags:
         release: release/ardent/{package}/{version}
-      type: git
-      url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.0.3-2
+      url: https://github.com/ros2-gbp/vision_opencv-release.git
+      version: 1.12.4-4
     source:
       type: git
-      url: https://github.com/ros2/common_interfaces.git
+      url: https://github.com/ros2/vision_opencv.git
       version: master
     status: maintained
 type: distribution

--- a/ardent/distribution.yaml
+++ b/ardent/distribution.yaml
@@ -126,7 +126,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ros_astra_camera.git
-      version: master
+      version: ros2
     status: maintained
   cartographer:
     release:
@@ -162,7 +162,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/class_loader.git
-      version: master
+      version: ros2
     status: maintained
   common_interfaces:
     release:
@@ -234,7 +234,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/depthimage_to_laserscan.git
-      version: master
+      version: ros2
     status: maintained
   example_interfaces:
     release:
@@ -334,7 +334,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/joystick_drivers.git
-      version: master
+      version: ros2
     status: maintained
   kdl_parser:
     release:
@@ -408,7 +408,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/pcl_conversions.git
-      version: master
+      version: ros2
     status: maintained
   pluginlib:
     release:
@@ -590,7 +590,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/robot_state_publisher.git
-      version: master
+      version: ros2
     status: maintained
   ros1_bridge:
     release:
@@ -723,7 +723,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/teleop_twist_joy.git
-      version: master
+      version: ros2
     status: maintained
   teleop_twist_keyboard:
     release:
@@ -734,7 +734,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/teleop_twist_keyboard.git
-      version: master
+      version: ros2
     status: maintained
   tinyxml2_vendor:
     release:
@@ -829,7 +829,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/urdfdom_headers.git
-      version: master
+      version: ros2
     status: maintained
   vision_opencv:
     release:
@@ -842,7 +842,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/vision_opencv.git
-      version: master
+      version: ros2
     status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
May need review for sanity checking.
I checked only duplicated source repos, so I likely missed repos where the repository name and the released package names are not matching.
Another follow up is that we have release repository duplicated in ros2-gbp that should be deleted and consolidated to host all the packages of the corresponding source repo