### PR TITLE
vision_msgs: 1.0.0-0 in 'ardent/distribution.yaml' [bloom]

### DIFF
--- a/ardent/distribution.yaml
+++ b/ardent/distribution.yaml
@@ -867,6 +867,22 @@ repositories:
       url: https://github.com/ros2/urdfdom_headers.git
       version: ros2
     status: maintained
+  vision_msgs:
+    doc:
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/ardent/{package}/{version}
+      url: https://github.com/Kukanani/vision_msgs-release.git
+      version: 1.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: ros2
+    status: maintained
   vision_opencv:
     release:
       packages:

--- a/ardent/distribution.yaml
+++ b/ardent/distribution.yaml
@@ -878,7 +878,6 @@ repositories:
       url: https://github.com/Kukanani/vision_msgs-release.git
       version: 1.0.0-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/Kukanani/vision_msgs.git
       version: ros2


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_msgs` to `1.0.0-0`:

- upstream repository: https://github.com/Kukanani/vision_msgs.git
- release repository: https://github.com/Kukanani/vision_msgs-release.git
- distro file: `ardent/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
