### PR TITLE
add bouncy distro

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -5,6 +5,7 @@
 release_platforms:
   ubuntu:
   - bionic
+  - xenial
 repositories:
 type: distribution
 version: 2

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+# ROS distribution file
+# see REP 143: http://ros.org/reps/rep-0143.html
+---
+release_platforms:
+  ubuntu:
+  - bionic
+repositories:
+type: distribution
+version: 2

--- a/index.yaml
+++ b/index.yaml
@@ -12,5 +12,8 @@ distributions:
   ardent:
     distribution: [ardent/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/ardent-cache.yaml.gz
+  bouncy:
+    distribution: [bouncy/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/bouncy-cache.yaml.gz
 type: index
 version: 3


### PR DESCRIPTION
This currently adds only bionic as a targeted platform.

@nuclearsandwich to give feedback on if we can / want to provide metadata for Ubuntu Xenial and Debian Stretch