### PR TITLE
rosidl_dds: 0.5.0-0 in 'bouncy/distribution.yaml'

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -398,6 +398,23 @@ repositories:
       url: https://github.com/ros2/rosidl.git
       version: master
     status: developed
+  rosidl_dds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_dds.git
+      version: master
+    release:
+      packages:
+      - rosidl_generator_dds_idl
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_dds-release.git
+      version: 0.5.0-0
+    source:
+      type: git
+      url: https://github.com/ros2/rosidl_dds.git
+      version: master
+    status: developed
   tinyxml2_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dds` to `0.5.0-0`:

- upstream repository: https://github.com/ros2/rosidl_dds.git
- release repository: https://github.com/ros2-gbp/rosidl_dds-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`