### PR TITLE
rmw_connext: 0.5.0-2 in 'bouncy/distribution.yaml'

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -386,7 +386,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 0.5.0-1
+      version: 0.5.0-2
     source:
       type: git
       url: https://github.com/ros2/rmw_connext.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `0.5.0-2`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.5.0-1`

Removed package rmw_connext_dynamic_cpp