### PR TITLE
vision_opencv: 2.0.3-0 in 'bouncy/distribution.yaml' [bloom]

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1289,11 +1289,14 @@ repositories:
       version: ros2
     release:
       packages:
+      - cv_bridge
       - image_geometry
+      - opencv_tests
+      - vision_opencv
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.0.1-0
+      version: 2.0.3-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `2.0.3-0`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.0.1-0`

## cv_bridge

```
* fix the build warning with colcon building
* optimize buffer type of imgmsg_to_cv2()
* add python3_opencv and python3_numpy as dependency
* uncrustify 0.67 coding style alignment
* Contributors: Mikael Arguedas, Lars Berscheid, Ethan Gao
```

## image_geometry

- No changes

## opencv_tests

```
* set zip_safe to avoid warning during installation
* migrate launch to launch.legacy
* fix exception of running launch after sourcing opencv_tests
* Contributors: Ethan Gao
```

## vision_opencv

- No changes
