### PR TITLE
vision_opencv: 2.0.5-0 in 'bouncy/distribution.yaml' [bloom]

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1300,11 +1300,13 @@ repositories:
       version: ros2
     release:
       packages:
+      - cv_bridge
       - image_geometry
+      - vision_opencv
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.0.3-0
+      version: 2.0.5-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `2.0.5-0`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.0.3-0`

## cv_bridge

```
* remove redundant ament_auto_lint dependency to release package
* fix test_encode_decode_cv2_compressed runtime error with JPEG2000
* change python3-numpy as build and execution dependency to fix building
  error while releasing package
* Contributor: Ethan Gao
```

## image_geometry

- No changes

## vision_opencv

- No changes
