### PR TITLE
ecl_lite: 1.0.0-0 in 'bouncy/distribution.yaml' [bloom]

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -307,6 +307,29 @@ repositories:
       url: https://github.com/ros2/depthimage_to_laserscan.git
       version: bouncy
     status: developed
+  ecl_lite:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: release/1.0-bouncy
+    release:
+      packages:
+      - ecl_config
+      - ecl_console
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_sigslots_lite
+      - ecl_time_lite
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_lite-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: release/1.0-bouncy
+    status: maintained
   ecl_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `1.0.0-0`:

- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`
