### PR TITLE
sophus: 1.0.2-0 in 'bouncy/distribution.yaml' [bloom]

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1136,6 +1136,21 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: bouncy
     status: maintained
+  sophus:
+    doc:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.0-bouncy
+    release:
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.0-bouncy
+    status: maintained
   sros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.0.2-0`:

- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`
