### PR TITLE
py_trees_msgs: 0.4.1-0 in 'bouncy/distribution.yaml' [bloom]

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -718,6 +718,17 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: bouncy
     status: developed
+  py_trees_msgs:
+    doc:
+      type: git
+      url: https://github.com/stonier/py_trees_msgs.git
+      version: release/0.4.x
+    release:
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/stonier/py_trees_msgs-release.git
+      version: 0.4.1-0
+    status: developed
   rcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_msgs` to `0.4.1-0`:

- upstream repository: https://github.com/stonier/py_trees_msgs.git
- release repository: https://github.com/stonier/py_trees_msgs-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`
