### PR TITLE
py_trees: 0.8.1-0 in 'bouncy/distribution.yaml' [bloom]

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -703,6 +703,21 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: bouncy
     status: developed
+  py_trees:
+    doc:
+      type: git
+      url: https://github.com/stonier/py_trees.git
+      version: release/0.8.x
+    release:
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/stonier/py_trees-release.git
+      version: 0.8.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/py_trees.git
+      version: release/0.8.x
+    status: developed
   py_trees_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `0.8.1-0`:

- upstream repository: https://github.com/stonier/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`
