### PR TITLE
py_trees: 0.8.2-0 in 'bouncy/distribution.yaml' [bloom]

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -712,7 +712,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 0.8.1-0
+      version: 0.8.2-0
     source:
       type: git
       url: https://github.com/stonier/py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `0.8.2-0`:

- upstream repository: https://github.com/stonier/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.8.1-0`
