### PR TITLE
object_msgs: 0.3.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -6,5 +6,16 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  object_msgs:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_object_msgs-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/intel/ros2_object_msgs.git
+      version: master
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `object_msgs` to `0.3.0-0`:

- upstream repository: https://github.com/intel/ros2_object_msgs.git
- release repository: https://github.com/ros2-gbp/ros2_object_msgs-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `null`
