### PR TITLE
object_msgs: 0.3.0-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -256,6 +256,17 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: master
     status: developed
+  object_msgs:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_object_msgs-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/intel/ros2_object_msgs.git
+      version: master
+    status: maintained
   osrf_pycommon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_msgs` to `0.3.0-1`:

- upstream repository: https://github.com/intel/ros2_object_msgs.git
- release repository: https://github.com/ros2-gbp/ros2_object_msgs-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
