### PR TITLE
rcl: 0.6.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -305,6 +305,27 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: developed
+  rcl:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl.git
+      version: master
+    release:
+      packages:
+      - rcl
+      - rcl_action
+      - rcl_lifecycle
+      - rcl_yaml_param_parser
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl.git
+      version: master
+    status: developed
   rcl_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `0.6.0-0`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## rcl

```
* Updated to expand node_secure_root using local_namespace (#300 <https://github.com/ros2/rcl/issues/300>)
* Moved stdatomic helper to rcutils (#324 <https://github.com/ros2/rcl/issues/324>)
* Added subfolder argument to the ROSIDL_GET_SRV_TYPE_SUPPORT macro (#322 <https://github.com/ros2/rcl/issues/322>)
* Updated to use new error handling API from rcutils (#314 <https://github.com/ros2/rcl/issues/314>)
* Fixed minor documentation issues (#305 <https://github.com/ros2/rcl/issues/305>)
* Added macro semicolons (#303 <https://github.com/ros2/rcl/issues/303>)
* Added Rcl timer with ros time (#286 <https://github.com/ros2/rcl/issues/286>)
* Updated to ensure that timer period is non-negative (#295 <https://github.com/ros2/rcl/issues/295>)
* Fixed calculation of next timer call (#291 <https://github.com/ros2/rcl/issues/291>)
* Updated to null deallocated jump callbacks (#294 <https://github.com/ros2/rcl/issues/294>)
* Included namespaces in get_node_names. (#287 <https://github.com/ros2/rcl/issues/287>)
* Fixed documentation issues (#288 <https://github.com/ros2/rcl/issues/288>)
* Updated to check if pointers are null before calling memset (#290 <https://github.com/ros2/rcl/issues/290>)
* Added multiple time jump callbacks to clock (#284 <https://github.com/ros2/rcl/issues/284>)
* Consolidated wait set functions (#285 <https://github.com/ros2/rcl/issues/285>)
  * Consolidate functions to clear wait set
  Added rcl_wait_set_clear()
  Added rcl_wait_set_resize()
  Removed
  rcl_wait_set_clear_subscriptions()
  rcl_wait_set_clear_guard_conditions()
  rcl_wait_set_clear_clients()
  rcl_wait_set_clear_services()
  rcl_wait_set_clear_timers()
  rcl_wait_set_resize_subscriptions()
  rcl_wait_set_resize_guard_conditions()
  rcl_wait_set_resize_timers()
  rcl_wait_set_resize_clients()
  rcl_wait_set_resize_services()
* ROS clock storage initially set to zero (#283 <https://github.com/ros2/rcl/issues/283>)
* Fixed issue with deallocation of parameter_files (#279 <https://github.com/ros2/rcl/issues/279>)
* Update to initialize memory before sending a message (#277 <https://github.com/ros2/rcl/issues/277>)
* Set error message when clock type is not ROS_TIME (#275 <https://github.com/ros2/rcl/issues/275>)
* Copy allocator passed in to clock init (#274 <https://github.com/ros2/rcl/issues/274>)
* Update to initialize timer with clock (#272 <https://github.com/ros2/rcl/issues/272>)
* Updated to use test_msgs instead of std_msgs in tests (#270 <https://github.com/ros2/rcl/issues/270>)
* Added regression test for node:__ns remapping (#263 <https://github.com/ros2/rcl/issues/263>)
* Updated to support Uncrustify 0.67 (#266 <https://github.com/ros2/rcl/issues/266>)
* Contributors: Chris Lalancette, Chris Ye, Dirk Thomas, Jacob Perron, Michael Carroll, Mikael Arguedas, Ruffin, Shane Loretz, William Woodall, dhood
```

## rcl_action

```
* Made rcl_action_get_*_name() functions check for empty action names. #329 <https://github.com/ros2/rcl/issues/329>
* Implemented Action client #319 <https://github.com/ros2/rcl/issues/319>
* Added function to check if goal can be transitioned to CANCELING (#325 <https://github.com/ros2/rcl/issues/325>)
* Implement goal handle (#320 <https://github.com/ros2/rcl/issues/320>)
* Update to use new error handling API from rcutils (#314 <https://github.com/ros2/rcl/issues/314>)
* Add action services and topics name getters #317 <https://github.com/ros2/rcl/issues/317>
* Implement init/fini functions for types (#312 <https://github.com/ros2/rcl/issues/312>)
* Refactor goal state machine implementation and add unit tests (#311 <https://github.com/ros2/rcl/issues/311>)
* Add missing visibilty control definitions (#315 <https://github.com/ros2/rcl/issues/315>)
* Add rcl_action package and headers (#307 <https://github.com/ros2/rcl/issues/307>)
* Contributors: Jacob Perron, Michel Hidalgo, William Woodall
```

## rcl_lifecycle

```
* Updated use new error handling API from rcutils (#314 <https://github.com/ros2/rcl/issues/314>)
* Deleted TRANSITION_SHUTDOWN (#313 <https://github.com/ros2/rcl/issues/313>)
* Refactored lifecycle (#298 <https://github.com/ros2/rcl/issues/298>)
  * no static initialization of states anymore
  * make transition labels more descriptive
  * introduce labeled keys
  * define default transition keys
  * fix memory management
  * introduce service for transition graph
  * export transition keys
  * remove keys, transition id unique, label ambiguous
  * semicolon for macro call
* Added macro semicolons (#303 <https://github.com/ros2/rcl/issues/303>)
* Fixed naming of configure_error transition (#292 <https://github.com/ros2/rcl/issues/292>)
* Removed use of uninitialized CMake var (#268 <https://github.com/ros2/rcl/issues/268>)
* Fixed rosidl dependencies (#265 <https://github.com/ros2/rcl/issues/265>)
  * [rcl_lifecycle] remove rosidl deps as this package doesnt generate any messages
  * depend on rosidl_generator_c
* Contributors: Chris Lalancette, Dirk Thomas, Karsten Knese, Mikael Arguedas, William Woodall
```

## rcl_yaml_param_parser

```
* Updated to use new error handling API from rcutils (#314 <https://github.com/ros2/rcl/issues/314>)
* Fixed FQN=//node_name when ns is / (#299 <https://github.com/ros2/rcl/issues/299>)
* Fixed documentation issues (#288 <https://github.com/ros2/rcl/issues/288>)
* Fixed to deallocate ret_val to avoid memory leak (#278 <https://github.com/ros2/rcl/issues/278>)
* Contributors: Chris Ye, William Woodall, dhood
```
