### PR TITLE
rclpy: 0.6.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -349,6 +349,22 @@ repositories:
       url: https://github.com/ros2/rcl_interfaces.git
       version: master
     status: developed
+  rclpy:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclpy.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rclpy-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclpy.git
+      version: master
+    status: developed
   rcutils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `0.6.0-0`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## rclpy

```
* Updated to use new error handling API from rcutils (#245 <https://github.com/ros2/rclpy/issues/245>)
* Added library path hook for platforms other than Windows. (#243 <https://github.com/ros2/rclpy/issues/243>)
* Avoided use of MethodType when monkey patching for tests (#239 <https://github.com/ros2/rclpy/issues/239>)
* Fixed repeated fini-ing on failure to parse yaml params (#238 <https://github.com/ros2/rclpy/issues/238>)
* Added methods on Mock class for Python 3.5 compatibility (#237 <https://github.com/ros2/rclpy/issues/237>)
* Added getter for tuple with seconds and nanoseconds (#235 <https://github.com/ros2/rclpy/issues/235>)
* Added new method to get node names and namespaces (#233 <https://github.com/ros2/rclpy/issues/233>)
* Fixed warning when parameter value is uninitialized. (#234 <https://github.com/ros2/rclpy/issues/234>)
* Added initial node parameters from a parameters yaml files and constructor arguments. (#225 <https://github.com/ros2/rclpy/issues/225>)
* Added callbacks when time jumps (#222 <https://github.com/ros2/rclpy/issues/222>)
* Updated to use consolidated rcl_wait_set_clear() (#230 <https://github.com/ros2/rclpy/issues/230>)
* Added parameter events publishing (#226 <https://github.com/ros2/rclpy/issues/226>)
* Added Node API method for setting the parameters_callback. (#228 <https://github.com/ros2/rclpy/issues/228>)
* Added test for when sim time is active but unset (#229 <https://github.com/ros2/rclpy/issues/229>)
* Added node parameters and parameter services (#214 <https://github.com/ros2/rclpy/issues/214>)
* Disabled 1kHz test on all platforms (#223 <https://github.com/ros2/rclpy/issues/223>)
* Updated to allow duration to be initialized with negative nanoseconds (#221 <https://github.com/ros2/rclpy/issues/221>)
* Updated to allow Duration to be negative (#220 <https://github.com/ros2/rclpy/issues/220>)
* Added a reference to its executor on Node (#218 <https://github.com/ros2/rclpy/issues/218>)
* Fixed executor.remove_node() (#217 <https://github.com/ros2/rclpy/issues/217>)
* Fixed bool return value for executor.add_node() (#216 <https://github.com/ros2/rclpy/issues/216>)
* Added TimeSource and support for ROS time (#210 <https://github.com/ros2/rclpy/issues/210>)
* Added Time, Duration, Clock wrapping rcl (#209 <https://github.com/ros2/rclpy/issues/209>)
* Contributors: Dirk Thomas, Michael Carroll, Mikael Arguedas, Shane Loretz, Steven! Ragnarök, William Woodall, dhood
```
