### PR TITLE
ros2cli: 0.6.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -503,6 +503,34 @@ repositories:
       url: https://github.com/ros2/rmw_opensplice.git
       version: master
     status: developed
+  ros2cli:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros2cli.git
+      version: master
+    release:
+      packages:
+      - ros2cli
+      - ros2lifecycle
+      - ros2msg
+      - ros2multicast
+      - ros2node
+      - ros2param
+      - ros2pkg
+      - ros2run
+      - ros2service
+      - ros2srv
+      - ros2topic
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2cli-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros2cli.git
+      version: master
+    status: maintained
   ros_workspace:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.6.0-0`:

- upstream repository: https://github.com/ros2/ros2cli.git
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
