### PR TITLE
resource_retriever: 2.1.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -526,6 +526,25 @@ repositories:
       url: https://github.com/ros2/realtime_support.git
       version: master
     status: developed
+  resource_retriever:
+    doc:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: ros2
+    release:
+      packages:
+      - libcurl_vendor
+      - resource_retriever
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/resource_retriever-release.git
+      version: 2.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: ros2
+    status: developed
   rmw:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `2.1.0-0`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## libcurl_vendor

```
* depend on curl (mapping to curl, libcurl4-openssl-dev) for packaging (#25 <https://github.com/ros/resource_retriever/issues/25>)
* add missing dependency on pkg-config (#19 <https://github.com/ros/resource_retriever/issues/19>)
* [libcurl_vendor] convert to ament and setup env hooks for library paths (#14 <https://github.com/ros/resource_retriever/issues/14>)
* Contributors: Dirk Thomas, Mikael Arguedas, William Woodall
```

## resource_retriever

```
* Make sure to export the include directory for resource_retriever. (#22 <https://github.com/ros/resource_retriever/issues/22>)
* Contributors: Chris Lalancette
```
