### PR TITLE
librealsense: 2.16.5-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -346,6 +346,19 @@ repositories:
       url: https://github.com/ros2/launch.git
       version: master
     status: maintained
+  librealsense:
+    release:
+      packages:
+      - librealsense2
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/librealsense-release.git
+      version: 2.16.5-0
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: ros2debian
+    status: maintained
   libyaml_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense` to `2.16.5-0`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/ros2-gbp/librealsense-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
