### PR TITLE
rmw_opensplice: 0.6.1-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -830,7 +830,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_opensplice-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_opensplice` to `0.6.1-0`:

- upstream repository: https://github.com/ros2/rmw_opensplice.git
- release repository: https://github.com/ros2-gbp/rmw_opensplice-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.6.0-0`
