### PR TITLE
demos: 0.6.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -221,6 +221,37 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: master
     status: developed
+  demos:
+    doc:
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: master
+    release:
+      packages:
+      - composition
+      - demo_nodes_cpp
+      - demo_nodes_cpp_native
+      - demo_nodes_py
+      - dummy_map_server
+      - dummy_robot_bringup
+      - dummy_sensors
+      - image_tools
+      - intra_process_demo
+      - lifecycle
+      - logging_demo
+      - pendulum_control
+      - pendulum_msgs
+      - topic_monitor
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/demos-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: master
+    status: developed
   example_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.6.0-0`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## composition

```
* Added semicolons to all RCLCPP and RCUTILS macros. (#278 <https://github.com/ros2/demos/issues/278>)
* Contributors: Chris Lalancette
```

## demo_nodes_cpp

```
* Added semicolons to all RCLCPP and RCUTILS macros. (#278 <https://github.com/ros2/demos/issues/278>)
* Removed parameter node, all nodes take parameter by default now (#265 <https://github.com/ros2/demos/issues/265>)
* Added example of registering custom parameter validation callbacks (#273 <https://github.com/ros2/demos/issues/273>)
* Removed imu_listener node (#272 <https://github.com/ros2/demos/issues/272>)
* Refined demo_nodes_cpp source codes (#269 <https://github.com/ros2/demos/issues/269>)
* Fixed typo in comment (#268 <https://github.com/ros2/demos/issues/268>)
* Removed rosidl deps as this package doesnt generate any messages (#264 <https://github.com/ros2/demos/issues/264>)
* Fixed no return code for main() in several files (#266 <https://github.com/ros2/demos/issues/266>)
* Contributors: Chris Lalancette, Mikael Arguedas, Yutaka Kondo, testkit
```

## demo_nodes_cpp_native

```
* Added semicolons to all RCLCPP and RCUTILS macros. (#278 <https://github.com/ros2/demos/issues/278>)
* Contributors: Chris Lalancette
```

## demo_nodes_py

```
* Updated package maintainer. (#286 <https://github.com/ros2/demos/issues/286>)
* Removed now redundant args=sys.argv (#274 <https://github.com/ros2/demos/issues/274>)
* Contributors: Michael Carroll, Mikael Arguedas
```

## dummy_map_server

- No changes

## dummy_robot_bringup

```
* Added missing launch_ros exec dependency (#277 <https://github.com/ros2/demos/issues/277>)
* Contributors: Mikael Arguedas
```

## dummy_sensors

```
* Added semicolons to all RCLCPP and RCUTILS macros. (#278 <https://github.com/ros2/demos/issues/278>)
* Contributors: Chris Lalancette
```

## image_tools

```
* Updated to prevent frame going out of scope when converting RGB -> BGR (#288 <https://github.com/ros2/demos/issues/288>)
* Added semicolons to all RCLCPP and RCUTILS macros. (#278 <https://github.com/ros2/demos/issues/278>)
* Updated to keep only the last sample in the image tools by default. (#238 <https://github.com/ros2/demos/issues/238>)
* Contributors: Chris Lalancette, sgvandijk
```

## intra_process_demo

- No changes

## lifecycle

```
* Cleaned up lifecycle demo (#283 <https://github.com/ros2/demos/issues/283>)
* Updated for refactoring in rclcpp (#276 <https://github.com/ros2/demos/issues/276>)
* Added semicolons to all RCLCPP and RCUTILS macros. (#278 <https://github.com/ros2/demos/issues/278>)
* Fixed typo in comment (#270 <https://github.com/ros2/demos/issues/270>)
* Contributors: Chris Lalancette, Karsten Knese, Yutaka Kondo
```

## logging_demo

```
* Updated package maintainer for logging_demo and topic_monitor (#285 <https://github.com/ros2/demos/issues/285>)
* Updated to use new error handling API from rcutils (#284 <https://github.com/ros2/demos/issues/284>)
* Added semicolons to all RCLCPP and RCUTILS macros. (#278 <https://github.com/ros2/demos/issues/278>)
* Updated to use add_compile_options instead of setting only cxx flags
* Contributors: Chris Lalancette, Mikael Arguedas, Scott K Logan, William Woodall
```

## pendulum_control

```
* Updated package maintainer. (#286 <https://github.com/ros2/demos/issues/286>)
* Updated to match rmw_fastrtps_dynamic_cpp (#271 <https://github.com/ros2/demos/issues/271>)
* Fixed spacing to comply with uncrusity 0.67 (#267 <https://github.com/ros2/demos/issues/267>)
* Fixed no return code for main() in several files (#266 <https://github.com/ros2/demos/issues/266>)
* Contributors: Dirk Thomas, Michael Carroll, Mikael Arguedas, testkit
```

## pendulum_msgs

```
* Updated package maintainer. (#286 <https://github.com/ros2/demos/issues/286>)
* Updated to use add_compile_options instead of setting only cxx flags
* Contributors: Michael Carroll, Mikael Arguedas
```

## topic_monitor

```
* Updated package maintainer for logging_demo and topic_monitor (#285 <https://github.com/ros2/demos/issues/285>)
* Fix lint warning from invalid escape sequences (#280 <https://github.com/ros2/demos/issues/280>)
* Contributors: Jacob Perron, Scott K Logan
```
