### PR TITLE
ecl_tools: 1.0.1-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -302,6 +302,25 @@ repositories:
       url: https://github.com/ros2/depthimage_to_laserscan.git
       version: ros2
     status: maintained
+  ecl_tools:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/1.0-crystal
+    release:
+      packages:
+      - ecl_build
+      - ecl_license
+      - ecl_tools
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/1.0-crystal
+    status: maintained
   example_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `1.0.1-1`:

- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
