### PR TITLE
sophus: 1.0.2-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1616,6 +1616,17 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: crystal
     status: maintained
+  sophus:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.0-crystal
+    status: maintained
   sros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.0.2-0`:

- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
