### PR TITLE
ecl_core: 1.0.1-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -302,6 +302,47 @@ repositories:
       url: https://github.com/ros2/depthimage_to_laserscan.git
       version: ros2
     status: maintained
+  ecl_core:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: release/1.0-crystal
+    release:
+      packages:
+      - ecl_command_line
+      - ecl_concepts
+      - ecl_containers
+      - ecl_converters
+      - ecl_core
+      - ecl_core_apps
+      - ecl_devices
+      - ecl_eigen
+      - ecl_exceptions
+      - ecl_filesystem
+      - ecl_formatters
+      - ecl_geometry
+      - ecl_ipc
+      - ecl_linear_algebra
+      - ecl_manipulators
+      - ecl_math
+      - ecl_mobile_robot
+      - ecl_mpl
+      - ecl_sigslots
+      - ecl_statistics
+      - ecl_streams
+      - ecl_threads
+      - ecl_time
+      - ecl_type_traits
+      - ecl_utilities
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_core-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: release/1.0-crystal
+    status: maintained
   ecl_lite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `1.0.1-0`:

- upstream repository: https://github.com/stonier/ecl_core.git
- release repository: https://github.com/yujinrobot-release/ecl_core-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## ecl_core

```
* metapackage tag dropped
```
